### PR TITLE
Added more instructive msgs when config is missing

### DIFF
--- a/Our.Umbraco.HealthChecks.Privacy/Checks/Privacy/CookiePolicyCheck.cs
+++ b/Our.Umbraco.HealthChecks.Privacy/Checks/Privacy/CookiePolicyCheck.cs
@@ -38,6 +38,10 @@ namespace Our.Umbraco.HealthChecks.Privacy.Checks.Privacy
         // todo: handle language files
         // public override string CheckErrorMessage => TextService.Localize("Our.Umbraco.HealthChecks.Privacy/cookiePolicyError");
         public override string CheckErrorMessage => "A Cookie Policy needs to be selected.";
+		
+		// todo: handle language files
+        // public override string CheckErrorMessage => TextService.Localize("Our.Umbraco.HealthChecks.Privacy/missingCookiePolicyError");
+        public override string MissingErrorMessage => "Please add an appSetting with 'Our.Umbraco.HealthChecks.Privacy.CookiePolicyUDI' as a key to your web.config";
 
         // todo: handle language files
         // public override string RectifySuccessMessage => TextService.Localize("Our.Umbraco.HealthChecks.Privacy/cookiePolicyRectifySuccess");

--- a/Our.Umbraco.HealthChecks.Privacy/Checks/Privacy/PrivacyPolicyCheck.cs
+++ b/Our.Umbraco.HealthChecks.Privacy/Checks/Privacy/PrivacyPolicyCheck.cs
@@ -34,6 +34,10 @@ namespace Our.Umbraco.HealthChecks.Privacy.Checks.Privacy
         // todo: handle language files
         // public override string CheckErrorMessage => TextService.Localize("Our.Umbraco.HealthChecks.Privacy/privacyPolicyError");
         public override string CheckErrorMessage => "A Privacy Policy needs to be selected.";
+		
+		// todo: handle language files
+        // public override string CheckErrorMessage => TextService.Localize("Our.Umbraco.HealthChecks.Privacy/missingPrivacyPolicyError");
+        public override string MissingErrorMessage => "Please add an appSetting with 'Our.Umbraco.HealthChecks.Privacy.PrivacyPolicyUDI' as a key to your web.config";
 
         // todo: handle language files
         // public override string RectifySuccessMessage => TextService.Localize("Our.Umbraco.HealthChecks.Privacy/privacyPolicyRectifySuccess");


### PR DESCRIPTION
This requires core updates to work - provided separately.

The aim is to provide a better error message when the config is missing. Below you can see the current error message at the bottom, and a slightly friendlier one set in the healthcheck in the first check

![image](https://user-images.githubusercontent.com/6873029/59275164-b1857b00-8c53-11e9-98ba-50537baeac2f.png)
